### PR TITLE
Retain access to datasettestinputs

### DIFF
--- a/mutect2.inputs.json
+++ b/mutect2.inputs.json
@@ -1,30 +1,30 @@
 {
   "Mutect2.gatk_docker": "broadinstitute/gatk:4.1.4.1",
 
-  "Mutect2.intervals": "/datasettestinputs/dataset/references/hg19/whole_exome_agilent_1.1_refseq_plus_3_boosters.Homo_sapiens_assembly19.baits.interval_list",
+  "Mutect2.intervals": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg19/whole_exome_agilent_1.1_refseq_plus_3_boosters.Homo_sapiens_assembly19.baits.interval_list",
   "Mutect2.scatter_count": 50,
   "Mutect2.m2_extra_args": "--downsampling-stride 20 --max-reads-per-alignment-start 6 --max-suspicious-reads-per-alignment-start 6",
   "Mutect2.filter_funcotations": "True",
   "Mutect2.funco_reference_version": "hg19",
-  "Mutect2.funco_data_sources_tar_gz": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/funcotator/funcotator_dataSources.v1.6.20190124s.tar.gz",
-  "Mutect2.funco_transcript_selection_list": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/funcotator/transcriptList.exact_uniprot_matches.AKT1_CRLF2_FGFR1.txt",
+  "Mutect2.funco_data_sources_tar_gz": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/funcotator/funcotator_dataSources.v1.6.20190124s.tar.gz",
+  "Mutect2.funco_transcript_selection_list": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/funcotator/transcriptList.exact_uniprot_matches.AKT1_CRLF2_FGFR1.txt",
   "Mutect2.max_retries": 3,
 
-  "Mutect2.ref_fasta": "/datasettestinputs/dataset/references/hg19/Homo_sapiens_assembly19.fasta",
-  "Mutect2.ref_dict": "/datasettestinputs/dataset/references/hg19/Homo_sapiens_assembly19.dict",
-  "Mutect2.ref_fai": "/datasettestinputs/dataset/references/hg19/Homo_sapiens_assembly19.fasta.fai",
-  "Mutect2.normal_reads": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143_normal.bam",
-  "Mutect2.normal_reads_index": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143_normal.bai",
-  "Mutect2.tumor_reads": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143.bam",
-  "Mutect2.tumor_reads_index": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143.bai",
+  "Mutect2.ref_fasta": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg19/Homo_sapiens_assembly19.fasta",
+  "Mutect2.ref_dict": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg19/Homo_sapiens_assembly19.dict",
+  "Mutect2.ref_fai": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg19/Homo_sapiens_assembly19.fasta.fai",
+  "Mutect2.normal_reads": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143_normal.bam",
+  "Mutect2.normal_reads_index": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143_normal.bai",
+  "Mutect2.tumor_reads": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143.bam",
+  "Mutect2.tumor_reads_index": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/HCC1143/HCC1143.bai",
 
-  "Mutect2.pon": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/Mutect2-exome-panel.vcf",
-  "Mutect2.pon_idx": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/Mutect2-exome-panel.vcf.idx",
-  "Mutect2.gnomad": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/af-only-gnomad.raw.sites.vcf",
-  "Mutect2.gnomad_idx": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/af-only-gnomad.raw.sites.vcf.idx",
-  "Mutect2.variants_for_contamination": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/small_exac_common_3.vcf",
-  "Mutect2.variants_for_contamination_idx": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/small_exac_common_3.vcf.idx",
-  "Mutect2.realignment_index_bundle": "/datasettestinputs/dataset/gatk4-somatic-snvs-indels/Homo_sapiens_assembly38.index_bundle"
+  "Mutect2.pon": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/Mutect2-exome-panel.vcf",
+  "Mutect2.pon_idx": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/Mutect2-exome-panel.vcf.idx",
+  "Mutect2.gnomad": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/af-only-gnomad.raw.sites.vcf",
+  "Mutect2.gnomad_idx": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/af-only-gnomad.raw.sites.vcf.idx",
+  "Mutect2.variants_for_contamination": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/small_exac_common_3.vcf",
+  "Mutect2.variants_for_contamination_idx": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/small_exac_common_3.vcf.idx",
+  "Mutect2.realignment_index_bundle": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-somatic-snvs-indels/Homo_sapiens_assembly38.index_bundle"
 
 }
 

--- a/mutect2.trigger.json
+++ b/mutect2.trigger.json
@@ -1,6 +1,6 @@
 {
-    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-somatic-snvs-indels-azure/az2.7.0/mutect2.wdl",
-    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-somatic-snvs-indels-azure/az2.7.0/mutect2.inputs.json",
+    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-somatic-snvs-indels-azure/main-azure/mutect2.wdl",
+    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-somatic-snvs-indels-azure/main-azure/mutect2.inputs.json",
     "WorkflowOptionsUrl":null,
     "WorkflowDependenciesUrl":null
 }


### PR DESCRIPTION
`datasettestinputs`'s `dataset` container is now readable anonymously, and thus cannot be mounted on AKS. This works around that limitation.